### PR TITLE
Fix warnings when using phpcs/phpunit

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -83,12 +83,22 @@ $GLOBALS['srfgFormats'] = [
 
 // Load hash format only if HashTables extension is initialised, otherwise 'Array' format is enough
 // FIXME: According to the INSTALL file only formats should be enabled, that "do not require further software to be installed (besides SMW)"
-if(	array_key_exists( 'ExtHashTables', $GLOBALS['wgAutoloadClasses'] ) && defined( 'ExtHashTables::VERSION' )
-	&& version_compare( ExtHashTables::VERSION, '0.999', '>=' )
-	|| isset( $GLOBALS['wgHashTables'] ) // Version < 1.0 alpha
+/**
+ * Fandom change - start
+ * Fix issue with warning when running phpcs/phpunit
+ * @author t-tomalak
+ */
+if ( isset( $GLOBALS['wgAutoloadClasses'] ) &&
+	 array_key_exists( 'ExtHashTables', $GLOBALS['wgAutoloadClasses'] ) &&
+	 defined( 'ExtHashTables::VERSION' )
+	 && version_compare( ExtHashTables::VERSION, '0.999', '>=' )
+	 || isset( $GLOBALS['wgHashTables'] ) // Version < 1.0 alpha
 ) {
 	$GLOBALS['srfgFormats'][] = 'hash';
 }
+/**
+ * Fandom change - end
+ */
 
 // Used for Array and Hash formats.
 // Allows value as string or object instances of Title or Article classes or an array


### PR DESCRIPTION
When runing phpcs/phpunit on composer autoload `$GLOBALS['wgAutoloadClasses']` is not defined and throws error, let's add check for that.

Don't merge it. 